### PR TITLE
Fix 'cointype' field in the 'Wallet.store' method

### DIFF
--- a/lib/Wallet.js
+++ b/lib/Wallet.js
@@ -197,9 +197,9 @@ export default class Wallet {
 				cipher: opts.cipher || 'aes-128-ctr',
 				kdf,
 				kdfparams,
-				mac: mac.toString('hex'),
-				coinType: 'icx'
+				mac: mac.toString('hex')
 			},
+		    coinType: 'icx'
 		};
 	}
 


### PR DESCRIPTION
A wallet created with the `Wallet.store` method cannot be imported in ICONex.
The `coinType` field shouldn't be inside the `crypto` field but at the root of the JSON object.

![aa](https://i.imgur.com/77066VU.png)