### PR TITLE
Fix transaction signing for transactions with empty arrays

### DIFF
--- a/lib/data/Util.js
+++ b/lib/data/Util.js
@@ -111,10 +111,10 @@ export function arrTraverse(arr) {
 			default:
 				break;
 		}
-
-		if (j < arr.length - 1) {
-			result += '.';
-		}
+		result += '.';
+	}
+	if (result.endsWith('.')) {
+		result = result.slice(0, -1);
 	}
 	result += ']';
 	return result;

--- a/lib/data/Util.js
+++ b/lib/data/Util.js
@@ -111,9 +111,11 @@ export function arrTraverse(arr) {
 			default:
 				break;
 		}
-		result += '.';
+
+		if (j < arr.length - 1) {
+			result += '.';
+		}
 	}
-	result = result.slice(0, -1);
 	result += ']';
 	return result;
 }


### PR DESCRIPTION
Only append '.' between array items in `arrTraverse`.

Fixes #8 