### PR TITLE
Set the Content-Type header for outgoing requests

### DIFF
--- a/lib/transport/http/client/HttpClient.js
+++ b/lib/transport/http/client/HttpClient.js
@@ -46,6 +46,7 @@ export default class HttpRequest {
 						const error = new NetworkError(req.responseText);
 						reject(error.toString());
 					};
+					req.setRequestHeader('Content-Type', 'application/json');
 					req.send(body);
 				});
 			},


### PR DESCRIPTION
I'm trying to use this library in a React Native application but it's currently throwing an error whenever I try to send any requests over the network.

The error message says that outgoing requests require a `Content-Type` header, this PR sets the `Content-Type` header to `application/json` because to my understanding all HTTP requests made by this library are JSON-RPC requests.

I haven't tested the change thoroughly (eg. within a web app), but it fixes the problem I was having with React Native.