### PR TITLE
Fix 'height' parameter as optional

### DIFF
--- a/lib/IconService.ts
+++ b/lib/IconService.ts
@@ -66,10 +66,10 @@ export default class IconService {
 
   /**
    * Get the total number of issued coins.
-   * @param {Hash} height - block Height.
+   * @param {Hash} [height] - block Height.
    * @return {HttpCall} The HttpCall instance for icx_getTotalSupply JSON-RPC API request.
    */
-  getTotalSupply(height: Hash): HttpCall<BigNumber> {
+  getTotalSupply(height?: Hash): HttpCall<BigNumber> {
     let params;
     if (height == undefined) {
       params = null;
@@ -85,10 +85,10 @@ export default class IconService {
   /**
    * Get the balance of the address.
    * @param {string} address - The EOA or SCORE address.
-   * @param {Hash} height - block Height.
+   * @param {Hash} [height] - block Height.
    * @return {HttpCall} The HttpCall instance for icx_getBalance JSON-RPC API request.
    */
-  getBalance(address: string, height: Hash): HttpCall<BigNumber> {
+  getBalance(address: string, height?: Hash): HttpCall<BigNumber> {
     let params;
     if (height == undefined) {
       params = { address };
@@ -182,10 +182,10 @@ export default class IconService {
   /**
    * @description Get the SCORE API list.
    * @param {string} address SCORE address
-   * @param {Hash} height block Height
+   * @param {Hash} [height] block Height
    * @return {array} The list of SCORE API
    */
-  getScoreApi(address: string, height: Hash): HttpCall<ScoreApiList> {
+  getScoreApi(address: string, height?: Hash): HttpCall<ScoreApiList> {
     let params;
     if (height == undefined) {
       params = { address };


### PR DESCRIPTION
# Description

`height` is a required parameter, and `undefined` value of `height` is checked, but a TypeScript error still occurs.

```ts
iconService.getBalance(address) // 2 arguments required, but only 1 present
```

Therefore, `height` should be optional to allow only one parameter sent.

**NB:** `height` is also specified as optional in the JSDoc (https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html).

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)