### PR TITLE
Add support for getting compressed publicKey

### DIFF
--- a/lib/Wallet.ts
+++ b/lib/Wallet.ts
@@ -352,6 +352,9 @@ export function convertPublicKeyFormat(
   publicKey: string,
   compressed: boolean
 ): string {
+  if (publicKey.length == 128) {
+    publicKey = "04" + publicKey;
+  }
   const bPubKey = Buffer.from(publicKey, "hex");
   return Buffer.from(secp256k1.publicKeyConvert(bPubKey, compressed)).toString(
     "hex"

--- a/lib/Wallet.ts
+++ b/lib/Wallet.ts
@@ -51,6 +51,8 @@ export default class Wallet {
 
   private pubKey: any;
 
+  private compressedPubKey: any;
+
   private address: string;
 
   /**
@@ -303,8 +305,9 @@ export default class Wallet {
    * Get public key of wallet instance.
    * @return {string} The public key.
    */
-  getPublicKey(): string {
-    return Buffer.from(this.pubKey).toString("hex");
+  getPublicKey(compressed = false): string {
+    if (!compressed) return Buffer.from(this.pubKey).toString("hex");
+    return Buffer.from(this.compressedPubKey).toString("hex");
   }
 
   /**
@@ -333,8 +336,24 @@ Object.defineProperty(Wallet.prototype, "pubKey", {
   },
 });
 
+Object.defineProperty(Wallet.prototype, "compressedPubKey", {
+  get: function get() {
+    return secp256k1.publicKeyCreate(this.privKey, true);
+  },
+});
+
 Object.defineProperty(Wallet.prototype, "address", {
   get: function get() {
     return addHxPrefix(sha3256(this.pubKey).slice(-40));
   },
 });
+
+export function convertPublicKeyFormat(
+  publicKey: string,
+  compressed: boolean
+): string {
+  const bPubKey = Buffer.from(publicKey, "hex");
+  return Buffer.from(secp256k1.publicKeyConvert(bPubKey, compressed)).toString(
+    "hex"
+  );
+}

--- a/test/Wallet.getPublicKey.ts
+++ b/test/Wallet.getPublicKey.ts
@@ -1,5 +1,6 @@
 import * as assert from 'assert';
-import IconService from '../lib';
+import { Wallet } from "../lib";
+import { convertPublicKeyFormat } from "../lib/Wallet";
 
 const tests = [{
   privateKey: '38f792b95a5202ab431bfc799f7e1e5c74ec0b9ede5c6142ee7364f2c84d72f6',
@@ -12,9 +13,15 @@ const tests = [{
 describe('Wallet', () => {
   describe('getPublicKey()', () => {
     tests.forEach((test) => {
-      const wallet = IconService.IconWallet.loadPrivateKey(test.privateKey);
+      const wallet = Wallet.loadPrivateKey(test.privateKey);
+      const uncompressedPublicKey = wallet.getPublicKey();
+      const compressedPublicKey = wallet.getPublicKey(true);
       it('should be same', () => {
-        assert.strictEqual(wallet.getPublicKey(), test.expectedPublicKey);
+        assert.strictEqual(uncompressedPublicKey, test.expectedPublicKey);
+      });
+      it('test compressed publicKey', () => {
+        //getPublicKey() actually returns slice(1) value of uncompressed PublicKey
+        assert.strictEqual(convertPublicKeyFormat(compressedPublicKey, false).slice(2), uncompressedPublicKey);
       });
     });
   });

--- a/test/Wallet.getPublicKey.ts
+++ b/test/Wallet.getPublicKey.ts
@@ -22,6 +22,8 @@ describe('Wallet', () => {
       it('test compressed publicKey', () => {
         //getPublicKey() actually returns slice(1) value of uncompressed PublicKey
         assert.strictEqual(convertPublicKeyFormat(compressedPublicKey, false).slice(2), uncompressedPublicKey);
+        assert.strictEqual(convertPublicKeyFormat(uncompressedPublicKey, true), compressedPublicKey);
+        assert.strictEqual(convertPublicKeyFormat("04" + uncompressedPublicKey, true), compressedPublicKey);
       });
     });
   });


### PR DESCRIPTION
* Add default parameter to Wallet.getPublicKey()
* it returns compressed/uncompressed publicKey according to passed argument value.
* passing false to getPublicKey(), getPublicKey returns uncompressed publicKey[1:] for compatibility