### PR TITLE
Fix validation failure on base tx

### DIFF
--- a/lib/data/Validator.ts
+++ b/lib/data/Validator.ts
@@ -168,10 +168,7 @@ export function checkDataInTransaction(transaction) {
       );
     }
     case "base": {
-      return (
-        Object.prototype.hasOwnProperty.call(transaction, "data") &&
-        hasProperties(transaction.data, ["result"])
-      );
+      return Object.prototype.hasOwnProperty.call(transaction, "data");
     }
     case "deposit": {
       return (


### PR DESCRIPTION
The platform defines base TX. So it needs to check data only. It removes checking codes for the field "result" (it's only for "icon" platform).